### PR TITLE
Light Painter for 1.21.6 to 1.21.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Light Painter [1.21.5]
+# Light Painter [1.21.6 - 1.21.8]
 <img src="/images/2.png" alt="Image3"/>
 
 ## Overview

--- a/datapack/pack.mcmeta
+++ b/datapack/pack.mcmeta
@@ -1,6 +1,6 @@
 {
    "pack":{
-      "pack_format":71,
+      "pack_format":81,
       "description":"Colored Lights"
    }
 }

--- a/resourcepack/assets/minecraft/post_effect/transparency.json
+++ b/resourcepack/assets/minecraft/post_effect/transparency.json
@@ -45,13 +45,15 @@
                 }
             ],
             "output": "swap1",
-            "uniforms": [
-                {
-                    "name":"Test",
-                    "type":"int",
-                    "values": [ 0 ]
-                }
-            ]
+            "uniforms": {
+                "TestConfig": [
+                    {
+                        "name":"Test",
+                        "type":"int",
+                        "value": 0
+                    }
+                ]
+            }
         },
         {
             "vertex_shader": "minecraft:post/aggregate",
@@ -63,13 +65,15 @@
                 }
             ],
             "output": "swap2",
-            "uniforms": [
-                {
-                    "name":"Test",
-                    "type":"int",
-                    "values": [ 0 ]
-                }
-            ]
+            "uniforms": {
+                "TestConfig": [
+                    {
+                        "name":"Test",
+                        "type":"int",
+                        "value": 0
+                    }
+                ]
+            }
         },
         {
             "vertex_shader": "minecraft:post/aggregate",
@@ -81,13 +85,15 @@
                 }
             ],
             "output": "swap1",
-            "uniforms": [
-                {
-                    "name":"Test",
-                    "type":"int",
-                    "values": [ 0 ]
-                }
-            ]
+            "uniforms": {
+                "TestConfig": [
+                    {
+                        "name":"Test",
+                        "type":"int",
+                        "value": 0
+                    }
+                ]
+            }
         },
         {
             "vertex_shader": "minecraft:post/aggregate",
@@ -99,13 +105,15 @@
                 }
             ],
             "output": "swap2",
-            "uniforms": [
-                {
-                    "name":"Test",
-                    "type":"int",
-                    "values": [ 0 ]
-                }
-            ]
+            "uniforms": {
+                "TestConfig": [
+                    {
+                        "name":"Test",
+                        "type":"int",
+                        "value": 0
+                    }
+                ]
+            }
         },
         {
             "vertex_shader": "minecraft:post/aggregate",
@@ -117,13 +125,15 @@
                 }
             ],
             "output": "swap1",
-            "uniforms": [
-                {
-                    "name":"Test",
-                    "type":"int",
-                    "values": [ 0 ]
-                }
-            ]
+            "uniforms": {
+                "TestConfig": [
+                    {
+                        "name":"Test",
+                        "type":"int",
+                        "value": 0
+                    }
+                ]
+            }
         },
         {
             "vertex_shader": "minecraft:post/aggregate_6",
@@ -144,13 +154,15 @@
                 }
             ],
             "output": "lights",
-            "uniforms": [
-                {
-                    "name":"Test",
-                    "type":"int",
-                    "values": [ 0 ]
-                }
-            ]
+            "uniforms": {
+                "TestConfig": [
+                    {
+                        "name":"Test",
+                        "type":"int",
+                        "value": 0
+                    }
+                ]
+            }
         },
         {
             "vertex_shader": "minecraft:post/zone_calc",
@@ -173,18 +185,20 @@
                 }
             ],
             "output": "swap1",
-            "uniforms": [
-                {
-                    "name": "Radius",
-                    "type":"float",
-                    "values": [ 0.01 ]
-                },
-                {
-                    "name": "Offset",
-                    "type":"float",
-                    "values": [ 0.0 ]
-                }
-            ]
+            "uniforms": {
+                "BlurConfig": [
+                    {
+                        "name": "Radius",
+                        "type":"float",
+                        "value": 0.01
+                    },
+                    {
+                        "name": "Offset",
+                        "type":"float",
+                        "value": 0.0
+                    }
+                ]
+            }
         },
         {
             "vertex_shader": "minecraft:post/blur_custom",
@@ -196,18 +210,20 @@
                 }
             ],
             "output": "swap3",
-            "uniforms": [
-                {
-                    "name": "Radius",
-                    "type":"float",
-                    "values": [ 0.015 ]
-                },
-                {
-                    "name": "Offset",
-                    "type":"float",
-                    "values": [ 7.0 ]
-                }
-            ]
+            "uniforms": {
+                "BlurConfig": [
+                    {
+                        "name": "Radius",
+                        "type":"float",
+                        "value": 0.015
+                    },
+                    {
+                        "name": "Offset",
+                        "type":"float",
+                        "value": 7.0
+                    }
+                ]
+            }
         },
         {
             "vertex_shader": "minecraft:post/blur_custom",
@@ -219,18 +235,20 @@
                 }
             ],
             "output": "swap1",
-            "uniforms": [
-                {
-                    "name": "Radius",
-                    "type":"float",
-                    "values": [ 0.02 ]
-                },
-                {
-                    "name": "Offset",
-                    "type":"float",
-                    "values": [ 21.0 ]
-                }
-            ]
+            "uniforms": {
+                "BlurConfig": [
+                    {
+                        "name": "Radius",
+                        "type":"float",
+                        "value": 0.02
+                    },
+                    {
+                        "name": "Offset",
+                        "type":"float",
+                        "value": 21.0
+                    }
+                ]
+            }
         },
         {
             "vertex_shader": "minecraft:post/blur_custom",
@@ -242,18 +260,20 @@
                 }
             ],
             "output": "swap3",
-            "uniforms": [
-                {
-                    "name": "Radius",
-                    "type":"float",
-                    "values": [ 0.02 ]
-                },
-                {
-                    "name": "Offset",
-                    "type":"float",
-                    "values": [ 45.0 ]
-                }
-            ]
+            "uniforms": {
+                "BlurConfig": [
+                    {
+                        "name": "Radius",
+                        "type":"float",
+                        "value": 0.02
+                    },
+                    {
+                        "name": "Offset",
+                        "type":"float",
+                        "value": 45.0
+                    }
+                ]
+            }
         },
         {
             "vertex_shader": "minecraft:post/light_apply",
@@ -401,13 +421,15 @@
                 }
             ],
             "output": "swap4",
-            "uniforms": [
-                {
-                    "name":"Test",
-                    "type":"int",
-                    "values": [ 0 ]
-                }
-            ]
+            "uniforms": {
+                "TestConfig": [
+                    {
+                        "name": "Test",
+                        "type":"int",
+                        "value": 0
+                    }
+                ]
+            }
         },
         {
             "vertex_shader": "minecraft:post/blit",
@@ -419,13 +441,15 @@
                 }
             ],
             "output": "minecraft:main",
-            "uniforms": [
-                {
-                    "name": "ColorModulate",
-                    "type": "vec4",
-                    "values": [ 1.0, 1.0, 1.0, 1.0 ]
-                }
-            ]
+            "uniforms": {
+                "BlitConfig": [
+                    {
+                        "name": "ColorModulate",
+                        "type": "vec4",
+                        "value": [ 1.0, 1.0, 1.0, 1.0 ]
+                    }
+                ]
+            }
         }
     ]
 }

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.fsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.fsh
@@ -1,18 +1,14 @@
 #version 150
 
 #moj_import <minecraft:fog.glsl>
+#moj_import <minecraft:dynamictransforms.glsl>
+#moj_import <minecraft:projection.glsl>
 #moj_import <minecraft:utils.glsl>
 
 uniform sampler2D Sampler0;
 
-uniform mat4 ProjMat;
-
-uniform vec4 ColorModulator;
-uniform float FogStart;
-uniform float FogEnd;
-uniform vec4 FogColor;
-
-in float vertexDistance;
+in float sphericalVertexDistance;
+in float cylindricalVertexDistance;
 in vec4 vertexColor;
 in vec2 texCoord0;
 in vec2 texCoord1;
@@ -25,7 +21,7 @@ in float scale;
 out vec4 fragColor;
 
 void main() {
-    bool hand = isHand(FogStart, FogEnd);
+    bool hand = isHand(FogRenderDistanceStart, FogRenderDistanceEnd);
     bool gui = isGUI(ProjMat);
 
     
@@ -35,7 +31,7 @@ void main() {
             discard;
         }
         color *= vertexColor * ColorModulator;
-        fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+        fragColor = apply_fog(color, sphericalVertexDistance, cylindricalVertexDistance, FogEnvironmentalStart, FogEnvironmentalEnd, FogRenderDistanceStart, FogRenderDistanceEnd, FogColor);
         fragColor.a = fragColor.a < 0.1 ? 0.1 : fragColor.a;
 
         if (!gui && gl_FragCoord.z <= LIGHTDEPTH) {
@@ -49,7 +45,7 @@ void main() {
         if (!(abs(texCoord2.x - 0.5) <= onePixelToUV && abs(texCoord2.y - 0.5) <= onePixelToUV)) {
             discard;
         }
-        fragColor = linear_fog(vertexColor, vertexDistance, FogStart, FogEnd, FogColor);
+        fragColor = apply_fog(vertexColor, sphericalVertexDistance, cylindricalVertexDistance, FogEnvironmentalStart, FogEnvironmentalEnd, FogRenderDistanceStart, FogRenderDistanceEnd, FogColor);
         fragColor.a = 1.0;
 
         gl_FragDepth = gl_FragCoord.z * LIGHTDEPTH;

--- a/resourcepack/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.vsh
+++ b/resourcepack/assets/minecraft/shaders/core/rendertype_item_entity_translucent_cull.vsh
@@ -2,6 +2,8 @@
 
 #moj_import <minecraft:light.glsl>
 #moj_import <minecraft:fog.glsl>
+#moj_import <minecraft:dynamictransforms.glsl>
+#moj_import <minecraft:projection.glsl>
 #moj_import <minecraft:utils.glsl>
 
 in vec3 Position;
@@ -14,18 +16,8 @@ in vec3 Normal;
 uniform sampler2D Sampler0;
 uniform sampler2D Sampler2;
 
-uniform mat4 ModelViewMat;
-uniform mat4 ProjMat;
-uniform int FogShape;
-uniform float FogStart;
-uniform float FogEnd;
-
-uniform vec3 Light0_Direction;
-uniform vec3 Light1_Direction;
-
-uniform vec4 ColorModulator;
-
-out float vertexDistance;
+out float sphericalVertexDistance;
+out float cylindricalVertexDistance;
 out vec4 vertexColor;
 out vec2 texCoord0;
 out vec2 texCoord1;
@@ -42,7 +34,8 @@ float opz(vec4 pos, float factor, float bias) {
 }
 
 void main() {
-    vertexDistance = fog_distance(Position, FogShape);
+    sphericalVertexDistance = fog_spherical_distance(Position);
+    cylindricalVertexDistance = fog_cylindrical_distance(Position);
     vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color) * texelFetch(Sampler2, UV2 / 16, 0);
     texCoord0 = UV0;
     texCoord1 = UV1;
@@ -50,7 +43,7 @@ void main() {
 
     vec4 tmpcol = texture(Sampler0, UV0);
     vec4 tmp = ModelViewMat * vec4(Position, 1.0);
-    bool hand = isHand(FogStart, FogEnd);
+    bool hand = isHand(FogRenderDistanceStart, FogRenderDistanceEnd);
     bool gui = isGUI(ProjMat);
 
     marker = float(!hand && !gui && (tmpcol.a == LIGHTALPHA));

--- a/resourcepack/assets/minecraft/shaders/include/utils.glsl
+++ b/resourcepack/assets/minecraft/shaders/include/utils.glsl
@@ -1,5 +1,7 @@
 #version 150
 
+#define PI 3.1415926535897932
+
 #define BIG 1000000
 #define FIXEDPOINT 1000.0
 #define DSCALE 10.0
@@ -10,7 +12,7 @@
 
 #define LIGHTINTENSITY 1.0
 #define LIGHTINTENSITYT 0.5
-#define LIGHTRANGE 128.0
+#define LIGHTRANGE 32.0
 #define LIGHTR 8.0
 #define SPREAD 3.0
 #define BOOST 10.0

--- a/resourcepack/assets/minecraft/shaders/post/aggregate.vsh
+++ b/resourcepack/assets/minecraft/shaders/post/aggregate.vsh
@@ -1,9 +1,13 @@
 #version 150
 
+#moj_import <minecraft:projection.glsl>
+
 in vec4 Position;
 
-uniform mat4 ProjMat;
-uniform vec2 OutSize;
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 SearchLayerSize;
+};
 
 out vec2 texCoord;
 flat out vec2 oneTexel;

--- a/resourcepack/assets/minecraft/shaders/post/aggregate_1.fsh
+++ b/resourcepack/assets/minecraft/shaders/post/aggregate_1.fsh
@@ -3,16 +3,23 @@
 #moj_import <minecraft:utils.glsl>
 
 uniform sampler2D SearchLayerSampler;
-uniform vec2 SearchLayerSize;
-uniform int Test;
+
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 SearchLayerSize;
+};
+
+layout(std140) uniform TestConfig {
+    int Test;
+};
 
 in vec2 texCoord;
 flat in vec2 oneTexel;
 
-out vec4 outColor;
+out vec4 fragColor;
 
 void main() {
-    outColor = vec4(0.0);
+    fragColor = vec4(0.0);
     vec2 samplepos = gl_FragCoord.xy - 0.5;
     samplepos = vec2(samplepos.x * float(AGGSTEP0), samplepos.y);
     if (samplepos.x < SearchLayerSize.x) {
@@ -21,14 +28,14 @@ void main() {
             tmpCounter += float(texture(SearchLayerSampler, (vec2(samplepos.x + float(i), samplepos.y) + 0.5) * oneTexel).a == 1.0);
         }
         tmpCounter /= 255.0;
-        outColor = vec4(vec3(tmpCounter), 1.0);
+        fragColor = vec4(vec3(tmpCounter), 1.0);
         if (Test == 1) {
-            outColor.rgb /= tmpCounter == 0.0 ? 1.0 : outColor.r;
-            outColor.rgb += vec3(0.2, 0.0, 0.0);
+            fragColor.rgb /= tmpCounter == 0.0 ? 1.0 : fragColor.r;
+            fragColor.rgb += vec3(0.2, 0.0, 0.0);
         }
     }
 
     if (abs(gl_FragCoord.x - 1.0) < 0.01) {
-        outColor.rgb = vec3(0.0, 1.0, 0.0);
+        fragColor.rgb = vec3(0.0, 1.0, 0.0);
     }
 }

--- a/resourcepack/assets/minecraft/shaders/post/aggregate_2.fsh
+++ b/resourcepack/assets/minecraft/shaders/post/aggregate_2.fsh
@@ -3,16 +3,23 @@
 #moj_import <minecraft:utils.glsl>
 
 uniform sampler2D SearchLayerSampler;
-uniform vec2 SearchLayerSize;
-uniform int Test;
+
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 SearchLayerSize;
+};
+
+layout(std140) uniform TestConfig {
+    int Test;
+};
 
 in vec2 texCoord;
 flat in vec2 oneTexel;
 
-out vec4 outColor;
+out vec4 fragColor;
 
 void main() {
-    outColor = texture(SearchLayerSampler, texCoord);
+    fragColor = texture(SearchLayerSampler, texCoord);
     float width = ceil(SearchLayerSize.x / float(AGGSTEP0));
     vec2 samplepos = gl_FragCoord.xy - 0.5;
     samplepos = vec2(samplepos.x - width, samplepos.y * float(AGGSTEP0));
@@ -22,10 +29,10 @@ void main() {
             tmpCounter += float(texture(SearchLayerSampler, (vec2(samplepos.x, samplepos.y + float(i)) + 0.5) * oneTexel).b * 255.0);
         }
         tmpCounter /= 255.0;
-        outColor = vec4(vec3(tmpCounter), 1.0);
+        fragColor = vec4(vec3(tmpCounter), 1.0);
         if (Test == 1) {
-            outColor.rgb /= tmpCounter == 0.0 ? 1.0 : outColor.r;
-            outColor.rgb += vec3(0.4, 0.0, 0.0);
+            fragColor.rgb /= tmpCounter == 0.0 ? 1.0 : fragColor.r;
+            fragColor.rgb += vec3(0.4, 0.0, 0.0);
         }
     }
 }

--- a/resourcepack/assets/minecraft/shaders/post/aggregate_3.fsh
+++ b/resourcepack/assets/minecraft/shaders/post/aggregate_3.fsh
@@ -3,16 +3,23 @@
 #moj_import <minecraft:utils.glsl>
 
 uniform sampler2D SearchLayerSampler;
-uniform vec2 SearchLayerSize;
-uniform int Test;
+
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 SearchLayerSize;
+};
+
+layout(std140) uniform TestConfig {
+    int Test;
+};
 
 in vec2 texCoord;
 flat in vec2 oneTexel;
 
-out vec4 outColor;
+out vec4 fragColor;
 
 void main() {
-    outColor = texture(SearchLayerSampler, texCoord);
+    fragColor = texture(SearchLayerSampler, texCoord);
     float width = ceil(SearchLayerSize.x / float(AGGSTEP0));
     float height = ceil(SearchLayerSize.y / float(AGGSTEP0));
     vec2 samplepos = gl_FragCoord.xy - 0.5;
@@ -23,10 +30,10 @@ void main() {
             tmpCounter += float(texture(SearchLayerSampler, (vec2(samplepos.x + float(i), samplepos.y) + 0.5) * oneTexel).b * 255.0);
         }
         tmpCounter /= 255.0;
-        outColor = vec4(vec3(tmpCounter), 1.0);
+        fragColor = vec4(vec3(tmpCounter), 1.0);
         if (Test == 1) {
-            outColor.rgb /= tmpCounter == 0.0 ? 1.0 : outColor.r;
-            outColor.rgb += vec3(0.5, 0.0, 0.0);
+            fragColor.rgb /= tmpCounter == 0.0 ? 1.0 : fragColor.r;
+            fragColor.rgb += vec3(0.5, 0.0, 0.0);
         }
     }
 }

--- a/resourcepack/assets/minecraft/shaders/post/aggregate_4.fsh
+++ b/resourcepack/assets/minecraft/shaders/post/aggregate_4.fsh
@@ -3,16 +3,23 @@
 #moj_import <minecraft:utils.glsl>
 
 uniform sampler2D SearchLayerSampler;
-uniform vec2 SearchLayerSize;
-uniform int Test;
+
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 SearchLayerSize;
+};
+
+layout(std140) uniform TestConfig {
+    int Test;
+};
 
 in vec2 texCoord;
 flat in vec2 oneTexel;
 
-out vec4 outColor;
+out vec4 fragColor;
 
 void main() {
-    outColor = texture(SearchLayerSampler, texCoord);
+    fragColor = texture(SearchLayerSampler, texCoord);
     float width = ceil(SearchLayerSize.x / float(AGGSTEP0));
     float width2 = ceil(width / float(AGGSTEP1));
     float height = ceil(SearchLayerSize.y / float(AGGSTEP0));
@@ -24,10 +31,10 @@ void main() {
             tmpCounter += float(texture(SearchLayerSampler, (vec2(samplepos.x, samplepos.y + float(i)) + 0.5) * oneTexel).b * 255.0);
         }
         tmpCounter /= 255.0;
-        outColor = vec4(vec3(tmpCounter), 1.0);
+        fragColor = vec4(vec3(tmpCounter), 1.0);
         if (Test == 1) {
-            outColor.rgb /= tmpCounter == 0.0 ? 1.0 : outColor.r;
-            outColor.rgb += vec3(0.6, 0.0, 0.0);
+            fragColor.rgb /= tmpCounter == 0.0 ? 1.0 : fragColor.r;
+            fragColor.rgb += vec3(0.6, 0.0, 0.0);
         }
     }
 }

--- a/resourcepack/assets/minecraft/shaders/post/aggregate_5.fsh
+++ b/resourcepack/assets/minecraft/shaders/post/aggregate_5.fsh
@@ -3,16 +3,23 @@
 #moj_import <minecraft:utils.glsl>
 
 uniform sampler2D SearchLayerSampler;
-uniform vec2 SearchLayerSize;
-uniform int Test;
+
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 SearchLayerSize;
+};
+
+layout(std140) uniform TestConfig {
+    int Test;
+};
 
 in vec2 texCoord;
 flat in vec2 oneTexel;
 
-out vec4 outColor;
+out vec4 fragColor;
 
 void main() {
-    outColor = texture(SearchLayerSampler, texCoord);
+    fragColor = texture(SearchLayerSampler, texCoord);
     float width = ceil(SearchLayerSize.x / float(AGGSTEP0));
     float width2 = ceil(width / float(AGGSTEP1));
     float height = ceil(SearchLayerSize.y / float(AGGSTEP0));
@@ -25,10 +32,10 @@ void main() {
             tmpCounter += float(texture(SearchLayerSampler, (vec2(samplepos.x, samplepos.y + float(i)) + 0.5) * oneTexel).b * 255.0);
         }
         tmpCounter /= 255.0;
-        outColor = vec4(vec3(tmpCounter), 1.0);
+        fragColor = vec4(vec3(tmpCounter), 1.0);
         if (Test == 1) {
-            outColor.rgb /= tmpCounter == 0.0 ? 1.0 : outColor.r;
-            outColor.rgb += vec3(0.7, 0.0, 0.0);
+            fragColor.rgb /= tmpCounter == 0.0 ? 1.0 : fragColor.r;
+            fragColor.rgb += vec3(0.7, 0.0, 0.0);
         }
     }
 }

--- a/resourcepack/assets/minecraft/shaders/post/aggregate_6.fsh
+++ b/resourcepack/assets/minecraft/shaders/post/aggregate_6.fsh
@@ -6,19 +6,28 @@
 uniform sampler2D SearchLayerSampler;
 uniform sampler2D ItemEntityDepthSampler;
 uniform sampler2D ColoredCentersSampler;
-uniform vec2 SearchLayerSize;
-uniform int Test;
+
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 SearchLayerSize;
+    vec2 ItemEntityDepthSize;
+    vec2 ColoredCentersSize;
+};
+
+layout(std140) uniform TestConfig {
+    int Test;
+};
 
 in vec2 texCoord;
 flat in vec2 inOneTexel;
 flat in float inAspectRatio;
 flat in float conversionK;
 
-out vec4 outColor;
+out vec4 fragColor;
 
 void main() {
     if (Test == 1) {
-        outColor = texture(SearchLayerSampler, texCoord);
+        fragColor = texture(SearchLayerSampler, texCoord);
     }
     float width = ceil(SearchLayerSize.x / float(AGGSTEP0));
     float width2 = ceil(width / float(AGGSTEP1));
@@ -43,7 +52,7 @@ void main() {
         }
     }
 
-    outColor = vec4(encodeInt(int(tmpCounter)).rgb, 69.0 / 255.0);
+    fragColor = vec4(encodeInt(int(tmpCounter)).rgb, 69.0 / 255.0);
 
     if (status == 1.0) {
         samplepos = vec2(2.0 * width + width2 + float(px), 0.0);
@@ -126,17 +135,17 @@ void main() {
         vec3 lightWorldCoord = vec3(samplepos * conversionK * lightDepth, lightDepth);
 
         if (pos.y == 0.0) {
-            outColor = encodeInt(int(lightWorldCoord.x * FIXEDPOINT));
+            fragColor = encodeInt(int(lightWorldCoord.x * FIXEDPOINT));
         } else if (pos.y == 1.0) {
-            outColor = encodeInt(int(lightWorldCoord.y * FIXEDPOINT));
+            fragColor = encodeInt(int(lightWorldCoord.y * FIXEDPOINT));
         } else if (pos.y == 2.0) {
-            outColor = encodeInt(int(lightWorldCoord.z * FIXEDPOINT));
+            fragColor = encodeInt(int(lightWorldCoord.z * FIXEDPOINT));
         } else {
-            outColor = sampleColor;
+            fragColor = sampleColor;
         }
 
-        if (Test == 1 && outColor.a == 0.0) {
-            outColor += vec4(0.0, 0.2, 0.0, 1.0);
+        if (Test == 1 && fragColor.a == 0.0) {
+            fragColor += vec4(0.0, 0.2, 0.0, 1.0);
         }
     }
 }

--- a/resourcepack/assets/minecraft/shaders/post/aggregate_6.vsh
+++ b/resourcepack/assets/minecraft/shaders/post/aggregate_6.vsh
@@ -4,9 +4,12 @@
 
 in vec4 Position;
 
-uniform mat4 ProjMat;
-uniform vec2 SearchLayerSize;
-uniform vec2 OutSize;
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 SearchLayerSize;
+    vec2 ItemEntityDepthSize;
+    vec2 ColoredCentersSize;
+};
 
 out vec2 texCoord;
 flat out vec2 inOneTexel;
@@ -25,8 +28,8 @@ void main(){
 
     inAspectRatio = SearchLayerSize.x / SearchLayerSize.y;
     inOneTexel = 1.0 / SearchLayerSize;
-    texCoord = Position.xy / OutSize;
-    conversionK = tan(FOV / 360.0 * 3.14159265358979) * 2.0;
+    texCoord = Position.xy;
+    conversionK = tan(FOV / 360.0 * PI) * 2.0;
 
     gl_Position = vec4(x, y, 0.2, 1.0);
 }

--- a/resourcepack/assets/minecraft/shaders/post/blur_custom.fsh
+++ b/resourcepack/assets/minecraft/shaders/post/blur_custom.fsh
@@ -5,10 +5,12 @@ uniform sampler2D InSampler;
 in vec2 texCoord;
 flat in float aspectRatio;
 
-uniform float Radius;
-uniform float Offset;
+layout(std140) uniform BlurConfig {
+    float Radius;
+    float Offset;
+};
 
-out vec4 outColor;
+out vec4 fragColor;
 
 #define ITERATIONS 6
 
@@ -84,5 +86,5 @@ void main() {
     for(int i = 0; i < ITERATIONS; i += 1) {
         tmpCol += texture(InSampler, texCoord + poissonDisk[i + int(Offset)] * vec2(1.0 / aspectRatio, 1.0) * Radius).rgb;
     }
-    outColor = vec4(tmpCol / ITERATIONS, 1.0);
+    fragColor = vec4(tmpCol / ITERATIONS, 1.0);
 }

--- a/resourcepack/assets/minecraft/shaders/post/blur_custom.vsh
+++ b/resourcepack/assets/minecraft/shaders/post/blur_custom.vsh
@@ -1,9 +1,12 @@
 #version 150
+#moj_import <minecraft:projection.glsl>
 
 in vec4 Position;
 
-uniform mat4 ProjMat;
-uniform vec2 OutSize;
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 InSize;
+};
 
 out vec2 texCoord;
 flat out float aspectRatio;

--- a/resourcepack/assets/minecraft/shaders/post/centers.vsh
+++ b/resourcepack/assets/minecraft/shaders/post/centers.vsh
@@ -1,9 +1,13 @@
 #version 150
 
+#moj_import <minecraft:projection.glsl>
+
 in vec4 Position;
 
-uniform mat4 ProjMat;
-uniform vec2 OutSize;
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 InSize;
+};
 
 out vec2 texCoord;
 flat out vec2 oneTexel;

--- a/resourcepack/assets/minecraft/shaders/post/filter.vsh
+++ b/resourcepack/assets/minecraft/shaders/post/filter.vsh
@@ -1,9 +1,13 @@
 #version 150
 
+#moj_import <minecraft:projection.glsl>
+
 in vec4 Position;
 
-uniform mat4 ProjMat;
-uniform vec2 OutSize;
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 InSize;
+};
 
 out vec2 texCoord;
 

--- a/resourcepack/assets/minecraft/shaders/post/light_apply.fsh
+++ b/resourcepack/assets/minecraft/shaders/post/light_apply.fsh
@@ -9,8 +9,14 @@ uniform sampler2D LightsSampler;
 uniform sampler2D VolumeSampler;
 uniform sampler2D BlurSampler;
 
-uniform vec2 VolumeSize;
-uniform vec2 LightsSize;
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 DiffuseSize;
+    vec2 DiffuseDepthSize;
+    vec2 LightsSize;
+    vec2 VolumeSize;
+    vec2 BlurSize;
+};
 
 in vec2 texCoord;
 flat in vec2 oneTexel;
@@ -19,11 +25,11 @@ flat in vec2 oneTexelVolume;
 flat in float aspectRatio;
 flat in float conversionK;
 
-out vec4 outColor;
+out vec4 fragColor;
 
 void main() {
     float depth = LinearizeDepth(texture(DiffuseDepthSampler, texCoord).r);
-    outColor = texture(DiffuseSampler, texCoord);
+    fragColor = texture(DiffuseSampler, texCoord);
     
     if (depth < LIGHTRANGE + LIGHTR) {
         vec4 aggColor = vec4(0.0, 0.0, 0.0, 1.0);
@@ -54,7 +60,7 @@ void main() {
             }
         }
 
-        outColor.rgb *= vec3(1.0) + aggColor.rgb * LIGHTINTENSITY * 5.0 * pow(1.0 - clamp(length(blurColor.rgb), 0.0, 1.0), 3.0);
-        outColor.rgb += LIGHTINTENSITY * aggColor.rgb * 0.1;
+        fragColor.rgb *= vec3(1.0) + aggColor.rgb * LIGHTINTENSITY * 5.0 * pow(1.0 - clamp(length(blurColor.rgb), 0.0, 1.0), 3.0);
+        fragColor.rgb += LIGHTINTENSITY * aggColor.rgb * 0.1;
     }
 }

--- a/resourcepack/assets/minecraft/shaders/post/light_apply.vsh
+++ b/resourcepack/assets/minecraft/shaders/post/light_apply.vsh
@@ -2,15 +2,21 @@
 
 #moj_import <minecraft:utils.glsl>
 #moj_import <minecraft:texint.glsl>
+#moj_import <minecraft:projection.glsl>
 
 in vec4 Position;
 
 uniform sampler2D LightsSampler;
 uniform sampler2D VolumeSampler;
-uniform mat4 ProjMat;
-uniform vec2 OutSize;
-uniform vec2 LightsSize;
-uniform vec2 VolumeSize;
+
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 DiffuseSize;
+    vec2 DiffuseDepthSize;
+    vec2 LightsSize;
+    vec2 VolumeSize;
+    vec2 BlurSize;
+};
 
 out vec2 texCoord;
 flat out vec2 oneTexel;
@@ -26,7 +32,7 @@ void main(){
     oneTexelVolume = 1.0 / VolumeSize;
     aspectRatio = OutSize.x / OutSize.y;
     texCoord = Position.xy;
-    conversionK = tan(FOV / 360.0 * 3.14159265358979) * 2.0;
+    conversionK = tan(FOV / 360.0 * PI) * 2.0;
 
     gl_Position = vec4(outPos.xy, 0.2, 1.0);
 }

--- a/resourcepack/assets/minecraft/shaders/post/light_apply_i.fsh
+++ b/resourcepack/assets/minecraft/shaders/post/light_apply_i.fsh
@@ -9,8 +9,14 @@ uniform sampler2D LightsSampler;
 uniform sampler2D VolumeSampler;
 uniform sampler2D CompareDepthSampler;
 
-uniform vec2 VolumeSize;
-uniform vec2 LightsSize;
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 DiffuseSize;
+    vec2 DiffuseDepthSize;
+    vec2 LightsSize;
+    vec2 VolumeSize;
+    vec2 BlurSize;
+};
 
 in vec2 texCoord;
 flat in vec2 oneTexel;
@@ -19,11 +25,11 @@ flat in vec2 oneTexelVolume;
 flat in float aspectRatio;
 flat in float conversionK;
 
-out vec4 outColor;
+out vec4 fragColor;
 
 void main() {
-    outColor = texture(DiffuseSampler, texCoord);
-    if (outColor.a > 0.0) {
+    fragColor = texture(DiffuseSampler, texCoord);
+    if (fragColor.a > 0.0) {
         float oDepth = texture(DiffuseDepthSampler, texCoord).r;
         float compDepth = texture(CompareDepthSampler, texCoord).r;
         float depth = LinearizeDepth(oDepth);
@@ -56,9 +62,9 @@ void main() {
                 }
             }
 
-            float Intensity = outColor.a < 1.0 ? LIGHTINTENSITYT : LIGHTINTENSITY;
-            outColor.rgb *= vec3(1.0) + aggColor.rgb * Intensity * 5.0 * pow(1.0 - clamp(length(outColor.rgb), 0.0, 1.0), 3.0);
-            outColor.rgb += Intensity * aggColor.rgb * 0.1;
+            float Intensity = fragColor.a < 1.0 ? LIGHTINTENSITYT : LIGHTINTENSITY;
+            fragColor.rgb *= vec3(1.0) + aggColor.rgb * Intensity * 5.0 * pow(1.0 - clamp(length(fragColor.rgb), 0.0, 1.0), 3.0);
+            fragColor.rgb += Intensity * aggColor.rgb * 0.1;
         }
     }
 }

--- a/resourcepack/assets/minecraft/shaders/post/light_apply_t.fsh
+++ b/resourcepack/assets/minecraft/shaders/post/light_apply_t.fsh
@@ -9,8 +9,14 @@ uniform sampler2D LightsSampler;
 uniform sampler2D VolumeSampler;
 uniform sampler2D CompareDepthSampler;
 
-uniform vec2 VolumeSize;
-uniform vec2 LightsSize;
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 DiffuseSize;
+    vec2 DiffuseDepthSize;
+    vec2 LightsSize;
+    vec2 VolumeSize;
+    vec2 BlurSize;
+};
 
 in vec2 texCoord;
 flat in vec2 oneTexel;
@@ -19,11 +25,11 @@ flat in vec2 oneTexelVolume;
 flat in float aspectRatio;
 flat in float conversionK;
 
-out vec4 outColor;
+out vec4 fragColor;
 
 void main() {
-    outColor = texture(DiffuseSampler, texCoord);
-    if (outColor.a > 0.0) {
+    fragColor = texture(DiffuseSampler, texCoord);
+    if (fragColor.a > 0.0) {
         float oDepth = texture(DiffuseDepthSampler, texCoord).r;
         float compDepth = texture(CompareDepthSampler, texCoord).r;
         float depth = LinearizeDepth(oDepth);
@@ -56,8 +62,8 @@ void main() {
                 }
             }
 
-            outColor.rgb *= vec3(1.0) + aggColor.rgb * LIGHTINTENSITYT * 5.0 * pow(1.0 - clamp(length(outColor.rgb), 0.0, 1.0), 3.0);
-            outColor.rgb += LIGHTINTENSITYT * aggColor.rgb * 0.1;
+            fragColor.rgb *= vec3(1.0) + aggColor.rgb * LIGHTINTENSITYT * 5.0 * pow(1.0 - clamp(length(fragColor.rgb), 0.0, 1.0), 3.0);
+            fragColor.rgb += LIGHTINTENSITYT * aggColor.rgb * 0.1;
         }
     }
 }

--- a/resourcepack/assets/minecraft/shaders/post/transparency.fsh
+++ b/resourcepack/assets/minecraft/shaders/post/transparency.fsh
@@ -15,7 +15,10 @@ uniform sampler2D WeatherDepthSampler;
 uniform sampler2D CloudsSampler;
 uniform sampler2D CloudsDepthSampler;
 
-uniform int Test;
+
+layout(std140) uniform TestConfig {
+    int Test;
+};
 
 in vec2 texCoord;
 in vec2 oneTexel;

--- a/resourcepack/assets/minecraft/shaders/post/transparency.vsh
+++ b/resourcepack/assets/minecraft/shaders/post/transparency.vsh
@@ -1,9 +1,13 @@
 #version 150
 
+#moj_import <minecraft:projection.glsl>
+
 in vec4 Position;
 
-uniform mat4 ProjMat;
-uniform vec2 OutSize;
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 InSize;
+};
 
 out vec2 texCoord;
 out vec2 oneTexel;

--- a/resourcepack/assets/minecraft/shaders/post/zone_calc.vsh
+++ b/resourcepack/assets/minecraft/shaders/post/zone_calc.vsh
@@ -7,9 +7,10 @@ in vec4 Position;
 
 uniform sampler2D LightsSampler;
 
-uniform mat4 ProjMat;
-uniform vec2 LightsSize;
-uniform vec2 OutSize;
+layout(std140) uniform SamplerInfo {
+    vec2 OutSize;
+    vec2 LightsSize;
+};
 
 out vec2 texCoord;
 flat out vec2 oneTexel;

--- a/resourcepack/pack.mcmeta
+++ b/resourcepack/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 55,
+    "pack_format": 64,
     "description": "Colored Lights"
   }
 }


### PR DESCRIPTION
Updated Light Painter to Minecraft 1.21.6. Also compatible with versions 1.21.7 and 1.21.8.

These lights are not compatible with previous versions due to uniform definition changes.